### PR TITLE
Update predictIt.js

### DIFF
--- a/predictIt.js
+++ b/predictIt.js
@@ -35,7 +35,7 @@ exports.contract = function(targetContract) {
 };
 
 exports.market = function(market) {
-  const url = base + 'ticker/' + market;
+  const url = base + 'markets/' + market;
   return apiCall(url);
 };
 


### PR DESCRIPTION
Predictit seems to no longer use "ticker" syntax for the market api and instead uses the /market/[market-id] syntax.